### PR TITLE
Fix crash when user-set extra doesn't have frame_info

### DIFF
--- a/src/opbeat.js
+++ b/src/opbeat.js
@@ -280,7 +280,7 @@ var Opbeat = {
      */
     setExtraContext: function(extra) {
        globalOptions.extra = extra || {};
-
+	
        return Opbeat;
     },
 
@@ -430,6 +430,7 @@ function normalizeFrame(frame) {
                         ', Func: ' + (frame.func || '?') ;
 
     // Add frame message to Extra payload
+    globalOptions.extra.frame_info = globalOptions.extra.frame_info || {};
     globalOptions.extra.frame_info['frame_' + frameInfoCounter++] = frameMessage;
 
     // normalize the frames data


### PR DESCRIPTION
If the user sets the extra via setExtraContext and doesn't include the new frame_info attribute, then the error reporting will crash when it tries to store stack frames. So, at the time that we're about to store the stack frames, make sure the frame_info property exists.
